### PR TITLE
Fix logout redirect to login page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -516,7 +516,7 @@ export default function Dashboard() {
   const handleSignOut = async () => {
     try {
       await signOut();
-      router.push("../");
+      router.push("/auth/login");
     } catch (error) {
       console.error("Error signing out:", error);
       toast({


### PR DESCRIPTION
Redirect users to `/auth/login` after logout to align with the expected authentication flow.

---

[Open in Web](https://cursor.com/agents?id=bc-92d4a304-ce67-49c6-a075-89fc9db26559) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-92d4a304-ce67-49c6-a075-89fc9db26559) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)